### PR TITLE
ci: healthcheck ping and `on:` config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,10 @@ name: Test workflows
 on:
   pull_request:
   push:
+    branches:
+      - '**'
+  schedule:
+    - cron: 25 15 * * *
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,3 +57,11 @@ jobs:
     steps:
       - name: Report success
         run: echo "It works!"
+      - name: Update Healthchecks.io
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          if [ -n "${HC_UUID}" ]; then
+            curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/${HC_UUID}
+          fi
+        env:
+          HC_UUID: ${{ secrets.HC_UUID }}


### PR DESCRIPTION
- **ci: send a healthcheck ping on success**
- **ci: run on push to branches not tags**

Fixes #19 
