### PR TITLE
ci: use environment variables and `renovate` in workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": [
+    "custom.regex",
     "github-actions",
     "pre-commit",
   ],
@@ -10,6 +11,7 @@
     ":enablePreCommit",
     ":semanticCommitTypeAll(fix)",
     "helpers:pinGitHubActionDigests",
+    "regexManagers:githubActionsVersions",
   ],
   "platformAutomerge": false,
 }

--- a/.github/workflows/libtest.yml
+++ b/.github/workflows/libtest.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Prepare Test Kitchen
         env:
           CHEF_LICENSE: accept-silent
-        run: chef gem install kitchen-docker
+          KITCHEN_DOCKER_VERSION: 3.0.0
+        run: chef gem install kitchen-docker --version ${{ env.KITCHEN_DOCKER_VERSION }}
       - name: Run Test Kitchen
         run: kitchen test
       - name: Run `semantic-release`

--- a/.github/workflows/libtest.yml
+++ b/.github/workflows/libtest.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Install Test Kitchen
         uses: actionshub/chef-install@d41f8dde8642d5cd05abefa333fbf2784cff830c # 3.0.0
         env:
+          # renovate: datasource=github-tags depName=chef/chef-workstation
           CHEF_WS_VERSION: 23.12.1055
         with:
           project: chef-workstation

--- a/.github/workflows/libtest.yml
+++ b/.github/workflows/libtest.yml
@@ -45,9 +45,11 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Install Test Kitchen
         uses: actionshub/chef-install@d41f8dde8642d5cd05abefa333fbf2784cff830c # 3.0.0
+        env:
+          CHEF_WS_VERSION: 23.12.1055
         with:
           project: chef-workstation
-          version: 23.12.1055
+          version:  ${{ env.CHEF_WS_VERSION }}
       - name: Prepare Test Kitchen
         env:
           CHEF_LICENSE: accept-silent


### PR DESCRIPTION
Resolves dafyddj/copier-docker-build#11

- **ci: enable `regexManagers:githubActionsVersions` preset**
- **ci: set environment variable `CHEF_WS_VERSION`**
- **ci: configure `renovate` datasource for Chef Workstation**
- **ci: set environment variable `KITCHEN_DOCKER_VERSION`**
