### PR TITLE
fix: `checkout` shouldnt persist creds

### DIFF
--- a/.github/workflows/libtest.yml
+++ b/.github/workflows/libtest.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false    # Prevent credentials conflict when running `semantic-release`
       - name: Debug on runner (When re-run with "Enable debug logging" checked)
         if: runner.debug
         uses: mxschmitt/action-tmate@a283f9441d2d96eb62436dc46d7014f5d357ac22 # v3.17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,14 +60,12 @@ jobs:
     name: Release
     needs:
       - results
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false    # Prevent credentials conflict when running `semantic-release`
       - uses: codfish/semantic-release-action@b621d34fabe0940f031e89b6ebfea28322892a10 # v3.5.0
         with:
           plugins: |


### PR DESCRIPTION
* as it conflicts with `semantic-release`
