### PR TITLE
ci(renovate): align with `base-bootstrap`-style Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     'github>techneg-it/.github',
     'github>techneg-it/.github:check-jsonschema',
+    'github>techneg-it/.github:copier-new',
     'github>techneg-it/.github:github-actions',
     'github>techneg-it/.github:pre-commit',
     'github>techneg-it/.github:python-versions',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,6 @@
     'github>techneg-it/.github:python-versions',
     'github>techneg-it/.github:weekly',
     ':automergeStableNonMajor',
-    ':semanticCommitTypeAll(fix)',
   ],
   customDatasources: {
     omnitruck: {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'github>techneg-it/.github',
+    'github>techneg-it/.github:check-jsonschema',
     'github>techneg-it/.github:github-actions',
     'github>techneg-it/.github:pre-commit',
     'github>techneg-it/.github:python-versions',


### PR DESCRIPTION
- **ci(renovate): use `check-jsonschema` preset**
- **ci(renovate): don't use semantic type `fix` anymore**
- **ci(renovate): use `copier-new` preset**
